### PR TITLE
Adding local development environment in podman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist
 vendor/
 bin/
+podman/**
+!podman/env.example
+.env

--- a/Makefile
+++ b/Makefile
@@ -334,8 +334,7 @@ dev-up: dev-setup
 dev-down:
 	@echo "Stopping development environment and removing volumes..."
 	$(PODMAN_COMPOSE) down -v
-	sudo rm -rf podman/data/* podman/config/*
-
+	
 ## Creates the admin account if it doesn't exist.
 ## Uses credentials from podman-compose.yml (admin/admin123/admin@example.com)
 ## Also creates a default team and adds the admin user to it.
@@ -360,7 +359,7 @@ dev-restart: dev-down dev-up
 dev-clean:
 	@echo "Cleaning development environment (removing containers, volumes, and data)..."
 	$(PODMAN_COMPOSE) down -v
-	sudo rm -rf podman/data/* podman/config/*
+	build/scripts/dir-cleanup.sh podman/data/ podman/config/
 	@echo "Development environment cleaned. Run 'make dev-up' to start fresh."
 
 ## Views Mattermost server logs.

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ else
 endif
 endif
 
+## Alias for server target - builds the server component.
+.PHONY: build
+build: server
+
 ## Ensures NPM dependencies are installed without having to run this all the time.
 webapp/node_modules: $(wildcard webapp/package.json)
 ifneq ($(HAS_WEBAPP),)
@@ -279,6 +283,24 @@ ifneq ($(HAS_WEBAPP),)
 endif
 	rm -fr build/bin/
 
+## Formats Go and Markdown code.
+.PHONY: format
+format:
+	@echo Formatting code...
+ifneq ($(HAS_SERVER),)
+	@echo Formatting Go files...
+	$(GO) fmt ./...
+endif
+	@echo Formatting Markdown files...
+	@if command -v prettier > /dev/null 2>&1; then \
+		prettier --write "**/*.md"; \
+	elif command -v npx > /dev/null 2>&1; then \
+		npx --yes prettier --write "**/*.md"; \
+	else \
+		echo "Warning: prettier not found. Install it with 'npm install -g prettier' to format Markdown files."; \
+	fi
+	@echo Formatting complete.
+
 .PHONY: logs
 logs:
 	./build/bin/pluginctl logs $(PLUGIN_ID)
@@ -286,6 +308,121 @@ logs:
 .PHONY: logs-watch
 logs-watch:
 	./build/bin/pluginctl logs-watch $(PLUGIN_ID)
+
+# Development environment management with Podman Compose
+PODMAN_COMPOSE_FILE ?= podman-compose.yml
+PODMAN_COMPOSE := podman-compose -f $(PODMAN_COMPOSE_FILE)
+
+## Sets up the required directories for Podman development stack.
+.PHONY: dev-setup
+dev-setup:
+	@./build/scripts/dev-preflight-check.sh
+
+## Starts the Podman Compose development stack.
+.PHONY: dev-up
+dev-up: dev-setup
+	@echo "Starting development environment..."
+	$(PODMAN_COMPOSE) up -d
+	@echo "Waiting for Mattermost to be ready..."
+	@timeout 60 bash -c 'until $$(curl -s http://localhost:8065/api/v4/system/ping > /dev/null 2>&1); do sleep 2; done' || echo "Mattermost is starting. Access at http://localhost:8065"
+	@echo "Creating admin account if it doesn't exist..."
+	@$(MAKE) dev-create-admin || echo "Admin account already exists or creation failed"
+
+## Stops the Podman Compose development stack and removes volumes.
+## This ensures a clean state for the next dev-up.
+.PHONY: dev-down
+dev-down:
+	@echo "Stopping development environment and removing volumes..."
+	$(PODMAN_COMPOSE) down -v
+	sudo rm -rf podman/data/* podman/config/*
+
+## Creates the admin account if it doesn't exist.
+## Uses credentials from podman-compose.yml (admin/admin123/admin@example.com)
+## Also creates a default team and adds the admin user to it.
+.PHONY: dev-create-admin
+dev-create-admin:
+	@./build/scripts/dev-create-admin.sh
+
+## Alias for dev-up
+.PHONY: dev-start
+dev-start: dev-up
+
+## Alias for dev-down
+.PHONY: dev-stop
+dev-stop: dev-down
+
+## Restarts the Podman Compose development stack.
+.PHONY: dev-restart
+dev-restart: dev-down dev-up
+
+## Removes containers, volumes, and data for a clean start.
+.PHONY: dev-clean
+dev-clean:
+	@echo "Cleaning development environment (removing containers, volumes, and data)..."
+	$(PODMAN_COMPOSE) down -v
+	sudo rm -rf podman/data/* podman/config/*
+	@echo "Development environment cleaned. Run 'make dev-up' to start fresh."
+
+## Views Mattermost server logs.
+.PHONY: dev-logs
+dev-logs:
+	$(PODMAN_COMPOSE) logs mattermost
+
+## Tails Mattermost server logs in real-time.
+.PHONY: dev-logs-watch
+dev-logs-watch:
+	$(PODMAN_COMPOSE) logs -f mattermost
+
+## Builds and deploys the plugin to the Podman development stack.
+.PHONY: dev-deploy
+dev-deploy: dist
+	@PLUGIN_ID=$(PLUGIN_ID) BUNDLE_NAME=dist/$(BUNDLE_NAME) ./build/scripts/dev-deploy.sh
+
+## Opens a shell in the Mattermost container.
+.PHONY: dev-shell
+dev-shell:
+	$(PODMAN_COMPOSE) exec mattermost /bin/sh
+
+## Shows status of Podman Compose services.
+.PHONY: dev-status
+dev-status:
+	$(PODMAN_COMPOSE) ps
+
+## Enables the plugin in the development environment.
+.PHONY: dev-enable
+dev-enable:
+	@./build/scripts/dev-pluginctl.sh enable
+
+## Disables the plugin in the development environment.
+.PHONY: dev-disable
+dev-disable:
+	@./build/scripts/dev-pluginctl.sh disable
+
+## Resets the plugin in the development environment (disables and re-enables).
+.PHONY: dev-reset
+dev-reset:
+	@./build/scripts/dev-pluginctl.sh reset
+
+## Views plugin logs in the development environment.
+.PHONY: dev-plugin-logs
+dev-plugin-logs:
+	@./build/scripts/dev-pluginctl.sh logs
+
+## Tails plugin logs in the development environment.
+.PHONY: dev-plugin-logs-watch
+dev-plugin-logs-watch:
+	@./build/scripts/dev-pluginctl.sh logs-watch
+
+## Pings the Mattermost healthcheck endpoint to verify server is responding.
+.PHONY: dev-check-ping
+dev-check-ping:
+	@echo "Checking Mattermost healthcheck endpoint..."
+	@if $(CURL) -f -s http://localhost:8065/api/v4/system/ping > /dev/null 2>&1; then \
+		echo "✓ Mattermost is responding (http://localhost:8065/api/v4/system/ping)"; \
+	else \
+		echo "✗ Mattermost is not responding. Is it running? (Try 'make dev-up')"; \
+		exit 1; \
+	fi
 
 # Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:

--- a/build/scripts/dev-check-container.sh
+++ b/build/scripts/dev-check-container.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# dev-check-container.sh - Verify Mattermost development container status
+#
+# PURPOSE:
+#   This script ensures the Mattermost development container is running before
+#   other scripts attempt to interact with it. It also loads environment variables
+#   from the podman/.env file to make credentials and configuration available to
+#   calling scripts.
+#
+# USAGE:
+#   This script is typically sourced by other development scripts:
+#       source build/scripts/dev-check-container.sh
+#
+# ENVIRONMENT:
+#   PODMAN_COMPOSE_FILE - Path to podman-compose file (default: podman-compose.yml)
+#
+# EXIT CODES:
+#   0 - Container is running and ready
+#   1 - Container is not running or dependencies missing
+#
+# NOTES:
+#   - This script changes to PROJECT_ROOT directory
+#   - Environment variables from podman/.env are exported to calling shell
+#   - Use 'set -a' pattern to automatically export variables when sourcing .env
+#
+
+set -euo pipefail
+
+# Determine script and project directories
+# Only set as readonly if not already defined (allows sourcing by other scripts)
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    readonly SCRIPT_DIR
+fi
+
+if [[ -z "${PROJECT_ROOT:-}" ]]; then
+    PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+    readonly PROJECT_ROOT
+fi
+
+if [[ -z "${PODMAN_COMPOSE_FILE:-}" ]]; then
+    PODMAN_COMPOSE_FILE="podman-compose.yml"
+    readonly PODMAN_COMPOSE_FILE
+fi
+
+# Check for required tools
+if ! command -v podman-compose &>/dev/null; then
+    echo "Error: podman-compose is not installed or not in PATH" >&2
+    echo "Install it with: pip install podman-compose" >&2
+    exit 1
+fi
+
+# Change to project root for consistent behavior
+cd "${PROJECT_ROOT}"
+
+# Verify Mattermost container is running
+# We check for "Up" or "starting" status in the podman-compose output
+if ! podman-compose -f "${PODMAN_COMPOSE_FILE}" ps | grep -qE "mattermost.*(Up|starting)"; then
+    echo "Error: Mattermost container is not running" >&2
+    echo "Start it with: make dev-up" >&2
+    exit 1
+fi
+
+# Load environment variables from podman/.env if present
+# Using 'set -a' causes all variables to be exported automatically
+readonly ENV_FILE="podman/.env"
+if [[ -f "${ENV_FILE}" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "${ENV_FILE}"
+    set +a
+fi

--- a/build/scripts/dev-create-admin.sh
+++ b/build/scripts/dev-create-admin.sh
@@ -1,0 +1,366 @@
+#!/bin/bash
+#
+# dev-create-admin.sh - Create admin user and default team in Mattermost
+#
+# PURPOSE:
+#   Automates the creation of an admin user account and default team in a local
+#   Mattermost development instance. This saves manual setup time and ensures
+#   a consistent development environment.
+#
+# USAGE:
+#   ./build/scripts/dev-create-admin.sh
+#   make dev-create-admin (recommended)
+#
+# ENVIRONMENT:
+#   MM_ADMIN_USERNAME  - Admin username (default: admin)
+#   MM_ADMIN_PASSWORD  - Admin password (default: admin123)
+#   MM_ADMIN_EMAIL     - Admin email (default: admin@example.com)
+#
+# EXIT CODES:
+#   0 - Admin account and team created/verified successfully
+#   1 - Creation failed (container not running, API errors, etc.)
+#
+# NOTES:
+#   - Idempotent: safe to run multiple times, detects existing user/team
+#   - Creates default team "mpct" and adds admin as team admin
+#   - Uses Mattermost REST API v4
+#   - First user can be created without authentication (Mattermost feature)
+#   - Subsequent operations require authentication (token or basic auth)
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # split to two lines for SC2155
+readonly SCRIPT_DIR
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)" # split to two lines for SC2155
+readonly PROJECT_ROOT
+
+# Source the helper script to verify container is running and load environment
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/dev-check-container.sh"
+
+cd "${PROJECT_ROOT}"
+
+# Check for required tools
+for tool in curl grep awk sed; do
+    if ! command -v "${tool}" &>/dev/null; then
+        echo "Error: Required tool '${tool}' is not installed" >&2
+        exit 1
+    fi
+done
+
+# Configuration with defaults from environment
+readonly ADMIN_USERNAME="${MM_ADMIN_USERNAME:-admin}"
+readonly ADMIN_PASSWORD="${MM_ADMIN_PASSWORD:-admin123}"
+readonly ADMIN_EMAIL="${MM_ADMIN_EMAIL:-admin@example.com}"
+readonly MATTERMOST_URL="http://localhost:8065"
+readonly TEAM_NAME="mpct"
+readonly TEAM_DISPLAY_NAME="MPCT"
+
+# Authentication token (populated after login)
+AUTH_TOKEN=""
+
+# Cleanup function to remove temporary files
+cleanup() {
+    if [[ -n "${COOKIE_JAR:-}" ]] && [[ -f "${COOKIE_JAR}" ]]; then
+        rm -f "${COOKIE_JAR}"
+    fi
+}
+
+# Register cleanup on script exit
+trap cleanup EXIT
+
+echo "Setting up admin account: ${ADMIN_USERNAME} / ${ADMIN_EMAIL}"
+echo ""
+
+#------------------------------------------------------------------------------
+# Helper Functions
+#------------------------------------------------------------------------------
+
+# Extract ID from JSON response
+# Mattermost API returns JSON like: {"id":"abc123...", ...}
+# We extract the first "id" field value using basic text tools
+#
+# Args:
+#   $1 - JSON string to parse
+# Returns:
+#   ID value (or empty string if not found)
+extract_id() {
+    local json="$1"
+    echo "${json}" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4
+}
+
+# Validate Mattermost ID format
+# Mattermost uses 26-character alphanumeric IDs
+#
+# Args:
+#   $1 - ID string to validate
+# Returns:
+#   0 if valid, 1 if invalid
+is_valid_id() {
+    local id="$1"
+    [[ -n "${id}" ]] && echo "${id}" | grep -qE '^[a-zA-Z0-9]{26}$'
+}
+
+# Authenticate and retrieve API token
+# Tries multiple methods to extract the auth token from login response
+#
+# Returns:
+#   Auth token string (or empty if login failed)
+get_auth_token() {
+    # Create temporary file for cookies
+    COOKIE_JAR="$(mktemp)"
+
+    # Attempt login and capture full response including headers
+    local login_response
+    login_response="$(curl -s -i -c "${COOKIE_JAR}" -X POST \
+        "${MATTERMOST_URL}/api/v4/users/login" \
+        -H "Content-Type: application/json" \
+        -d "{\"login_id\":\"${ADMIN_USERNAME}\",\"password\":\"${ADMIN_PASSWORD}\"}" 2>&1 || true)"
+
+    # Method 1: Extract from Token header (preferred)
+    local token
+    token="$(echo "${login_response}" | grep -i "^Token:" | sed 's/^Token: //' | tr -d '\r\n')"
+
+    # Method 2: Extract from Set-Cookie header
+    if [[ -z "${token}" ]]; then
+        token="$(echo "${login_response}" | grep -i "^Set-Cookie:" | \
+                 grep -o "MMAUTHTOKEN=[^;]*" | sed 's/MMAUTHTOKEN=//' | head -1)"
+    fi
+
+    # Method 3: Read from cookie jar file
+    if [[ -z "${token}" ]] && [[ -f "${COOKIE_JAR}" ]]; then
+        token="$(grep -i "MMAUTHTOKEN" "${COOKIE_JAR}" | awk '{print $NF}' | head -1)"
+    fi
+
+    echo "${token}"
+}
+
+# Make authenticated API call to Mattermost
+# Supports both token and basic authentication
+#
+# Args:
+#   $1 - HTTP method (GET, POST, PUT, etc.)
+#   $2 - Full URL to call
+#   $3 - Optional JSON data for request body
+# Returns:
+#   API response body
+api_call() {
+    local method="${1:-GET}"
+    local url="$2"
+    local data="${3:-}"
+
+    # Build curl command based on auth method and whether we have data
+    if [[ -n "${AUTH_TOKEN}" ]]; then
+        # Use token authentication (preferred)
+        if [[ -n "${data}" ]]; then
+            curl -s -X "${method}" \
+                -H "Authorization: Bearer ${AUTH_TOKEN}" \
+                -H "Content-Type: application/json" \
+                -d "${data}" \
+                "${url}"
+        else
+            curl -s -X "${method}" \
+                -H "Authorization: Bearer ${AUTH_TOKEN}" \
+                "${url}"
+        fi
+    else
+        # Fall back to basic authentication
+        if [[ -n "${data}" ]]; then
+            curl -s -X "${method}" \
+                -u "${ADMIN_USERNAME}:${ADMIN_PASSWORD}" \
+                -H "Content-Type: application/json" \
+                -d "${data}" \
+                "${url}"
+        else
+            curl -s -X "${method}" \
+                -u "${ADMIN_USERNAME}:${ADMIN_PASSWORD}" \
+                "${url}"
+        fi
+    fi
+}
+
+#------------------------------------------------------------------------------
+# Main Script Logic
+#------------------------------------------------------------------------------
+
+# Step 1: Create admin user
+# First user in Mattermost can be created without authentication
+echo "Creating admin user..."
+user_create_response="$(curl -s -X POST "${MATTERMOST_URL}/api/v4/users" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"${ADMIN_EMAIL}\",\"username\":\"${ADMIN_USERNAME}\",\"password\":\"${ADMIN_PASSWORD}\",\"allow_marketing\":false}" \
+    2>&1 || true)"
+
+# Determine if creation succeeded, user already exists, or failed
+USER_ID=""
+if echo "${user_create_response}" | grep -q "\"username\":\"${ADMIN_USERNAME}\""; then
+    echo "✓ Admin account created successfully"
+    USER_ID="$(extract_id "${user_create_response}")"
+    # Allow time for user to be fully processed in the system
+    sleep 2
+elif echo "${user_create_response}" | grep -qiE "already exists|already registered|unique constraint"; then
+    echo "✓ Admin account already exists"
+    # Retrieve user ID via API lookup
+    user_response="$(api_call GET "${MATTERMOST_URL}/api/v4/users/username/${ADMIN_USERNAME}")"
+    USER_ID="$(extract_id "${user_response}")"
+else
+    echo "Error: Failed to create admin account" >&2
+    echo "Response: ${user_create_response}" >&2
+    exit 1
+fi
+
+# Validate we have a user ID before proceeding
+if [[ -z "${USER_ID}" ]]; then
+    echo "Error: Could not determine user ID" >&2
+    exit 1
+fi
+
+# Step 2: Authenticate for subsequent operations
+echo "Authenticating..."
+AUTH_TOKEN="$(get_auth_token)"
+
+# Retry authentication if it fails (API may need a moment)
+readonly MAX_RETRIES=3
+retry_count=0
+while [[ -z "${AUTH_TOKEN}" ]] && (( retry_count < MAX_RETRIES )); do
+    retry_count=$((retry_count + 1))
+    if (( retry_count < MAX_RETRIES )); then
+        echo "  Retry ${retry_count}/${MAX_RETRIES}..."
+        sleep 2
+        AUTH_TOKEN="$(get_auth_token)"
+    fi
+done
+
+# Warn if authentication failed, but continue with basic auth fallback
+if [[ -z "${AUTH_TOKEN}" ]]; then
+    echo "Warning: Failed to authenticate after ${MAX_RETRIES} attempts" >&2
+    echo "  Will attempt basic authentication for remaining operations" >&2
+else
+    echo "✓ Authentication successful"
+fi
+
+echo ""
+echo "Setting up default team..."
+
+# Step 3: Check if team exists or create it
+team_response="$(api_call GET "${MATTERMOST_URL}/api/v4/teams/name/${TEAM_NAME}" 2>&1 || true)"
+
+TEAM_ID=""
+# Validate response contains team name (indicates successful lookup)
+if echo "${team_response}" | grep -q "\"name\":\"${TEAM_NAME}\""; then
+    TEAM_ID="$(extract_id "${team_response}")"
+    if is_valid_id "${TEAM_ID}"; then
+        echo "✓ Team '${TEAM_NAME}' already exists"
+    else
+        # Invalid ID format, treat as not found
+        TEAM_ID=""
+    fi
+fi
+
+# Create team if it doesn't exist
+if [[ -z "${TEAM_ID}" ]]; then
+    echo "Creating team '${TEAM_NAME}'..."
+    team_create_response="$(api_call POST "${MATTERMOST_URL}/api/v4/teams" \
+        "{\"name\":\"${TEAM_NAME}\",\"display_name\":\"${TEAM_DISPLAY_NAME}\",\"type\":\"O\"}")"
+
+    if echo "${team_create_response}" | grep -q "\"name\":\"${TEAM_NAME}\""; then
+        # Successfully created - extract and validate ID
+        TEAM_ID="$(extract_id "${team_create_response}")"
+        if is_valid_id "${TEAM_ID}"; then
+            echo "✓ Team '${TEAM_NAME}' created successfully"
+        else
+            echo "Error: Failed to extract valid team ID from response" >&2
+            echo "Response: ${team_create_response}" >&2
+            exit 1
+        fi
+    elif echo "${team_create_response}" | grep -qiE "already exists|already registered"; then
+        # Race condition: team was created between our check and creation attempt
+        echo "✓ Team '${TEAM_NAME}' already exists"
+        team_response="$(api_call GET "${MATTERMOST_URL}/api/v4/teams/name/${TEAM_NAME}")"
+        if echo "${team_response}" | grep -q "\"name\":\"${TEAM_NAME}\""; then
+            TEAM_ID="$(extract_id "${team_response}")"
+            if [[ -z "${TEAM_ID}" ]] || ! is_valid_id "${TEAM_ID}"; then
+                echo "Error: Failed to extract valid team ID" >&2
+                echo "Response: ${team_response}" >&2
+                exit 1
+            fi
+        else
+            echo "Error: Failed to retrieve team after creation" >&2
+            echo "Response: ${team_response}" >&2
+            exit 1
+        fi
+    else
+        echo "Error: Failed to create team" >&2
+        echo "Response: ${team_create_response}" >&2
+        echo "Note: Admin user may need system admin privileges to create teams" >&2
+        exit 1
+    fi
+fi
+
+# Final validation that we have a team ID
+if [[ -z "${TEAM_ID}" ]]; then
+    echo "Error: Could not determine team ID" >&2
+    exit 1
+fi
+
+# Step 4: Add user to team (if not already a member)
+member_check_response="$(api_call GET "${MATTERMOST_URL}/api/v4/teams/${TEAM_ID}/members/${USER_ID}" 2>&1 || true)"
+
+if echo "${member_check_response}" | grep -q '"user_id"'; then
+    echo "✓ Admin user is already a member of team '${TEAM_NAME}'"
+else
+    echo "Adding admin user to team '${TEAM_NAME}'..."
+    member_response="$(api_call POST "${MATTERMOST_URL}/api/v4/teams/${TEAM_ID}/members" \
+        "{\"team_id\":\"${TEAM_ID}\",\"user_id\":\"${USER_ID}\"}")"
+
+    if echo "${member_response}" | grep -q '"user_id"'; then
+        echo "✓ Admin user added to team '${TEAM_NAME}'"
+    elif echo "${member_response}" | grep -qiE "already exists|already a member"; then
+        # Race condition: user was added between check and addition
+        echo "✓ Admin user is already a member of team '${TEAM_NAME}'"
+    else
+        echo "Error: Failed to add admin user to team" >&2
+        echo "Response: ${member_response}" >&2
+        echo "Note: Admin user may need system admin privileges to add members" >&2
+        exit 1
+    fi
+fi
+
+# Step 5: Set user as team admin
+echo "Setting admin user as team admin..."
+role_update_response="$(api_call PUT \
+    "${MATTERMOST_URL}/api/v4/teams/${TEAM_ID}/members/${USER_ID}/roles" \
+    '{"roles":"team_admin team_user"}')"
+
+# API returns {"status":"OK"} on success (case may vary)
+if echo "${role_update_response}" | grep -qiE '"status":"ok"'; then
+    echo "✓ Admin user set as team admin"
+elif echo "${role_update_response}" | grep -qiE "error|failed"; then
+    # Not fatal - user can still use Mattermost, just won't have team admin privileges
+    echo "Warning: Failed to set team admin role" >&2
+    echo "Response: ${role_update_response}" >&2
+else
+    # Other status values might indicate success (e.g., "success")
+    if echo "${role_update_response}" | grep -qi '"status"'; then
+        echo "✓ Admin user set as team admin"
+    else
+        echo "Warning: Unexpected response when setting team admin role" >&2
+        echo "Response: ${role_update_response}" >&2
+    fi
+fi
+
+echo ""
+echo "======================================================================"
+echo "✓ Admin account and team setup complete!"
+echo "======================================================================"
+echo ""
+echo "Login credentials:"
+echo "  Username: ${ADMIN_USERNAME}"
+echo "  Email:    ${ADMIN_EMAIL}"
+echo "  Password: ${ADMIN_PASSWORD}"
+echo ""
+echo "Team: ${TEAM_DISPLAY_NAME} (${TEAM_NAME})"
+echo ""
+echo "Login at: ${MATTERMOST_URL}/login"
+echo ""

--- a/build/scripts/dev-deploy.sh
+++ b/build/scripts/dev-deploy.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# dev-deploy.sh - Deploy plugin to local Mattermost development environment
+#
+# PURPOSE:
+#   Builds and deploys the Mattermost plugin to a running Podman development
+#   stack. This script locates the latest plugin bundle and uses pluginctl
+#   to install it on the local Mattermost instance.
+#
+# USAGE:
+#   ./build/scripts/dev-deploy.sh
+#   make deploy (recommended - ensures build happens first)
+#
+# ENVIRONMENT:
+#   PLUGIN_ID           - Plugin identifier (default: mattermost-community-toolkit)
+#   BUNDLE_NAME         - Path to plugin bundle, or auto-detect latest in dist/
+#   MM_ADMIN_TOKEN      - Admin auth token (preferred)
+#   MM_ADMIN_USERNAME   - Admin username (fallback auth method)
+#   MM_ADMIN_PASSWORD   - Admin password (used with username)
+#
+# EXIT CODES:
+#   0 - Plugin deployed successfully
+#   1 - Deployment failed (missing dependencies, container not running, etc.)
+#
+# NOTES:
+#   - Requires Mattermost container to be running (checked via dev-check-container.sh)
+#   - Authentication credentials should be set in podman/.env
+#   - After deployment, plugin must be enabled via 'make dev-enable' or System Console
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # split to two lines for SC2155
+readonly SCRIPT_DIR
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)" # split to two lines for SC2155
+readonly PROJECT_ROOT
+
+# Source the helper script to verify container is running and load environment
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/dev-check-container.sh"
+
+cd "${PROJECT_ROOT}"
+
+# Check for required tools
+if [[ ! -x "./build/bin/pluginctl" ]]; then
+    echo "Error: pluginctl not found at ./build/bin/pluginctl" >&2
+    echo "Build the project first with: make all" >&2
+    exit 1
+fi
+
+echo "Deploying plugin to development environment..."
+
+# Validate deployment credentials are configured
+if [[ -z "${MM_ADMIN_TOKEN:-}" ]] && [[ -z "${MM_ADMIN_USERNAME:-}" ]]; then
+    echo "Warning: No authentication credentials configured" >&2
+    echo "  Set MM_ADMIN_TOKEN or MM_ADMIN_USERNAME/MM_ADMIN_PASSWORD" >&2
+    echo "  in podman/.env (see podman/env.example for template)" >&2
+    echo "" >&2
+    echo "Deployment may fail without proper authentication." >&2
+    # Continue anyway - pluginctl will fail with a clear error if auth is required
+fi
+
+# Get plugin configuration from environment or use defaults
+readonly PLUGIN_ID="${PLUGIN_ID:-mattermost-community-toolkit}"
+BUNDLE_NAME="${BUNDLE_NAME:-}"
+
+# Auto-detect latest bundle if not explicitly specified
+if [[ -z "${BUNDLE_NAME}" ]]; then
+    # Find most recently modified .tar.gz file in dist/
+    BUNDLE_NAME="$(find dist -maxdepth 1 -name "*.tar.gz" -type f -printf "%T@ %p\n" 2>/dev/null | \
+                   sort -rn | head -1 | cut -d' ' -f2-)"
+
+    if [[ -z "${BUNDLE_NAME}" ]]; then
+        echo "Error: No plugin bundle found in dist/" >&2
+        echo "Build the plugin first with: make dist" >&2
+        exit 1
+    fi
+
+    echo "Using bundle: ${BUNDLE_NAME}"
+fi
+
+# Verify bundle file exists and is readable
+if [[ ! -f "${BUNDLE_NAME}" ]]; then
+    echo "Error: Bundle file not found: ${BUNDLE_NAME}" >&2
+    exit 1
+fi
+
+if [[ ! -r "${BUNDLE_NAME}" ]]; then
+    echo "Error: Bundle file not readable: ${BUNDLE_NAME}" >&2
+    exit 1
+fi
+
+# Deploy the plugin using pluginctl
+# MM_SERVICESETTINGS_SITEURL tells pluginctl where to find the Mattermost API
+MM_SERVICESETTINGS_SITEURL="http://localhost:8065" \
+    ./build/bin/pluginctl deploy "${PLUGIN_ID}" "${BUNDLE_NAME}"
+
+echo ""
+echo "Plugin deployed successfully!"
+echo "Next steps:"
+echo "  - Enable: make dev-enable"
+echo "  - Or enable via System Console at http://localhost:8065"

--- a/build/scripts/dev-pluginctl.sh
+++ b/build/scripts/dev-pluginctl.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# dev-pluginctl.sh - Execute pluginctl commands in development environment
+#
+# PURPOSE:
+#   Centralized script for running pluginctl commands against a local Mattermost
+#   development environment. This script handles environment setup, container
+#   verification, and credential management for all pluginctl operations.
+#
+# USAGE:
+#   ./build/scripts/dev-pluginctl.sh <command>
+#
+#   Where <command> is one of: enable, disable, reset, logs, logs-watch
+#
+# EXAMPLES:
+#   ./build/scripts/dev-pluginctl.sh enable      # Enable the plugin
+#   ./build/scripts/dev-pluginctl.sh disable     # Disable the plugin
+#   ./build/scripts/dev-pluginctl.sh reset       # Reset (disable and re-enable) the plugin
+#   ./build/scripts/dev-pluginctl.sh logs        # View plugin logs
+#   ./build/scripts/dev-pluginctl.sh logs-watch  # Tail plugin logs in real-time
+#
+# ENVIRONMENT:
+#   PLUGIN_ID               - Plugin identifier (default: mattermost-community-toolkit)
+#   MM_SERVICESETTINGS_SITEURL - Mattermost server URL (default: http://localhost:8065)
+#   MM_ADMIN_TOKEN          - Admin auth token (preferred)
+#   MM_ADMIN_USERNAME       - Admin username (fallback auth method)
+#   MM_ADMIN_PASSWORD       - Admin password (used with username)
+#
+# EXIT CODES:
+#   0 - Command executed successfully
+#   1 - Command failed (invalid command, missing dependencies, container not running, etc.)
+#
+# NOTES:
+#   - Requires Mattermost container to be running (checked via dev-check-container.sh)
+#   - Authentication credentials should be set in podman/.env
+#   - This script is typically called via Makefile targets (dev-enable, dev-disable, etc.)
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # split to two lines for SC2155
+readonly SCRIPT_DIR
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)" # split to two lines for SC2155
+readonly PROJECT_ROOT
+
+# Source the helper script to verify container is running and load environment
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/dev-check-container.sh"
+
+cd "${PROJECT_ROOT}"
+
+# Validate command argument
+if [[ $# -ne 1 ]]; then
+    echo "Error: Missing command argument" >&2
+    echo "Usage: $0 <command>" >&2
+    echo "  Commands: enable, disable, reset, logs, logs-watch" >&2
+    exit 1
+fi
+
+readonly COMMAND="$1"
+
+# Validate command is one of the supported commands
+case "${COMMAND}" in
+    enable|disable|reset|logs|logs-watch)
+        # Valid command, continue
+        ;;
+    *)
+        echo "Error: Invalid command: ${COMMAND}" >&2
+        echo "Valid commands: enable, disable, reset, logs, logs-watch" >&2
+        exit 1
+        ;;
+esac
+
+# Check for required tools
+if [[ ! -x "./build/bin/pluginctl" ]]; then
+    echo "Error: pluginctl not found at ./build/bin/pluginctl" >&2
+    echo "Build the project first with: make all" >&2
+    exit 1
+fi
+
+# Get plugin configuration from environment or use defaults
+readonly PLUGIN_ID="${PLUGIN_ID:-mattermost-community-toolkit}"
+readonly SITE_URL="${MM_SERVICESETTINGS_SITEURL:-http://localhost:8065}"
+
+# Execute the pluginctl command
+MM_SERVICESETTINGS_SITEURL="${SITE_URL}" \
+    ./build/bin/pluginctl "${COMMAND}" "${PLUGIN_ID}"
+

--- a/build/scripts/dev-preflight-check.sh
+++ b/build/scripts/dev-preflight-check.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# dev-preflight-check.sh - Preflight checks for development environment setup
+#
+# PURPOSE:
+#   This script performs preflight checks and idempotent setup for the development
+#   environment. It validates that required configuration exists and ensures
+#   necessary directories are created with proper permissions.
+#
+# USAGE:
+#   Run directly or via make target:
+#       ./build/scripts/dev-preflight-check.sh
+#       make dev-setup
+#
+# ENVIRONMENT:
+#   PROJECT_ROOT - Root directory of the project (auto-detected)
+#
+# EXIT CODES:
+#   0 - All checks passed and setup completed successfully
+#   1 - Missing required configuration or setup failed
+#
+# NOTES:
+#   - This script is idempotent and safe to run multiple times
+#   - Only creates directories if they don't already exist
+#   - Only sets permissions when needed
+#   - Checks for podman/.env file existence before proceeding
+#
+
+set -euo pipefail
+
+# Determine script and project directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+readonly PROJECT_ROOT
+
+# Change to project root for consistent behavior
+cd "${PROJECT_ROOT}"
+
+# Define paths
+readonly ENV_FILE="podman/.env"
+readonly ENV_EXAMPLE="podman/env.example"
+
+# Directories that need to be created
+readonly REQUIRED_DIRS=(
+    "podman/data/mattermost/plugins"
+    "podman/data/mattermost/client/plugins"
+    "podman/data/postgres"
+    "podman/config"
+)
+
+# Directories that need specific permissions
+readonly CHMOD_DIRS=(
+    "podman/config"
+    "podman/data"
+)
+
+echo "Running preflight checks for development environment..."
+
+# Check 1: Verify podman/.env file exists
+if [[ ! -f "${ENV_FILE}" ]]; then
+    echo "Error: Required file '${ENV_FILE}' does not exist" >&2
+    echo "" >&2
+    echo "To fix this, copy the example environment file:" >&2
+    echo "  cp ${ENV_EXAMPLE} ${ENV_FILE}" >&2
+    echo "" >&2
+    echo "Then edit ${ENV_FILE} and configure:" >&2
+    echo "  - Database credentials (POSTGRES_*)" >&2
+    echo "  - Mattermost settings (MM_*)" >&2
+    echo "  - Admin credentials for plugin deployment" >&2
+    echo "" >&2
+    exit 1
+fi
+
+echo "✓ Environment file '${ENV_FILE}' exists"
+
+# Check 2: Create required directories if they don't exist
+echo "Checking required directories..."
+directories_created=0
+
+for dir in "${REQUIRED_DIRS[@]}"; do
+    if [[ ! -d "${dir}" ]]; then
+        echo "  Creating: ${dir}"
+        mkdir -p "${dir}"
+        directories_created=$((directories_created + 1))
+    else
+        echo "  ✓ Exists: ${dir}"
+    fi
+done
+
+if [[ ${directories_created} -gt 0 ]]; then
+    echo "Created ${directories_created} director(y|ies)"
+else
+    echo "All required directories already exist"
+fi
+
+# Check 3: Set permissions on directories that need them
+echo "Setting directory permissions..."
+permissions_set=0
+
+for dir in "${CHMOD_DIRS[@]}"; do
+    if [[ -d "${dir}" ]]; then
+        # Check if we need to set permissions
+        # We'll try to set them regardless to ensure they're correct
+        if chmod -R 777 "${dir}" 2>/dev/null; then
+            echo "  ✓ Permissions set: ${dir}"
+            permissions_set=$((permissions_set + 1))
+        else
+            echo "  ⚠ Warning: Could not set permissions on ${dir} (may require sudo)" >&2
+        fi
+    fi
+done
+
+echo ""
+echo "✓ Preflight checks complete. Development environment is ready."
+

--- a/build/scripts/dev-preflight-check.sh
+++ b/build/scripts/dev-preflight-check.sh
@@ -101,9 +101,14 @@ permissions_set=0
 
 for dir in "${CHMOD_DIRS[@]}"; do
     if [[ -d "${dir}" ]]; then
-        # Check if we need to set permissions
-        # We'll try to set them regardless to ensure they're correct
-        if chmod -R 777 "${dir}" 2>/dev/null; then
+        # Check if we need to set permissions - We'll try to set them regardless
+        # to ensure they're correct.
+        #
+        # Permissions of 775 is used here instead of 755 as the matermost
+        # config file is being generated as UID/GID which is not the current users (despite
+        # podman configuraiton to do otherwise). Since this is dev/test infra (local machine)
+        # this seemed acceptable.
+        if sudo chmod -R 775 "${dir}" 2>/dev/null; then
             echo "  ✓ Permissions set: ${dir}"
             permissions_set=$((permissions_set + 1))
         else

--- a/build/scripts/dir-cleanup.sh
+++ b/build/scripts/dir-cleanup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Check if any arguments were provided
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <dir1> [dir2] [dir3] ..."
+    exit 1
+fi
+
+# Store directories in an array
+dirs=("$@")
+
+# Display what will be removed
+echo "The following directories will be removed:"
+for dir in "${dirs[@]}"; do
+    echo "  - $dir"
+done
+echo
+
+# Ask for confirmation
+read -p "Are you sure you want to remove these directories? [y/N] " response
+
+if [[ "$response" =~ ^[Yy]$ ]]; then
+    for dir in "${dirs[@]}"; do
+        if [[ -d "$dir" || -f "$dir" ]]; then # optionally supports files if they were passed in
+            sudo rm -rf "$dir"
+            echo "Removed: $dir"
+        else
+            echo "(Skipped) directory already removed: $dir"
+        fi
+    done
+    echo "Cleanup complete."
+else
+    echo "Cleanup cancelled."
+    exit 0
+fi

--- a/docs/PODMAN_DEVELOPMENT.md
+++ b/docs/PODMAN_DEVELOPMENT.md
@@ -224,7 +224,7 @@ make dev-enable
 The setup process automatically creates the required directories with proper permissions via the `dev-setup` target. However, if you encounter permission issues with the config or data directories, you can manually fix them:
 
 ```bash
-chmod -R 755 podman/config podman/data/mattermost
+chmod -R 775 podman/config podman/data/mattermost
 ```
 
 ### Debugging Workflow

--- a/docs/PODMAN_DEVELOPMENT.md
+++ b/docs/PODMAN_DEVELOPMENT.md
@@ -224,7 +224,7 @@ make dev-enable
 The setup process automatically creates the required directories with proper permissions via the `dev-setup` target. However, if you encounter permission issues with the config or data directories, you can manually fix them:
 
 ```bash
-chmod -R 777 podman/config podman/data/mattermost
+chmod -R 755 podman/config podman/data/mattermost
 ```
 
 ### Debugging Workflow

--- a/docs/PODMAN_DEVELOPMENT.md
+++ b/docs/PODMAN_DEVELOPMENT.md
@@ -1,0 +1,393 @@
+# Podman Development Environment
+
+This document describes how to use the Podman Compose-based development environment for testing the Mattermost Community Toolkit plugin locally.
+
+## Overview
+
+The development environment provides a complete, isolated Mattermost instance with PostgreSQL, suitable for testing plugin functionality without affecting a production server.
+
+## Prerequisites
+
+- Podman and Podman Compose installed
+- Make utility (standard on Linux/macOS)
+- Network access to pull container images
+
+## Quick Start
+
+1. **Start the development environment:**
+
+   ```bash
+   make dev-up
+   ```
+
+2. **Wait for Mattermost to be ready:**
+
+   The `dev-up` target will wait up to 60 seconds for Mattermost to become ready. You can access it at http://localhost:8065
+
+3. **First-time setup:**
+
+   - Open http://localhost:8065 in your browser
+   - Create your admin account (or use the credentials from `podman/env.example`)
+   - Complete the initial setup wizard
+
+4. **Configure plugin deployment credentials:**
+
+   You need to set environment variables for plugin deployment. You can either:
+
+   **Option A: Use an admin token (recommended)**
+
+   ```bash
+   export MM_ADMIN_TOKEN="your-admin-token-here"
+   ```
+  
+   To get a token:
+
+   - Log into Mattermost
+   - Go to Menu > System Console > Integrations > Bot Accounts
+   - Choose to enable bot accounts
+   - Go to Menu > Integrations > Bot Accounts
+   - Add a Bot Account for the plugin (gives us a token to use for auth)
+      - Bot Account will need role: `system admin`
+
+   **Option B: Use username/password**
+
+   ```bash
+   export MM_ADMIN_USERNAME="admin"
+   export MM_ADMIN_PASSWORD="your-password"
+   ```
+
+5. **Deploy the plugin:**
+
+   ```bash
+   make dev-deploy
+   ```
+
+6. **Enable the plugin:**
+
+   ```bash
+   make dev-enable
+   ```
+
+   Or enable it via System Console > Plugins > Community Toolkit > Enable
+
+7. **Test your plugin:**
+   - Access Mattermost at http://localhost:8065
+   - Create test users and channels
+   - Test plugin functionality
+
+## Make Targets
+
+### Environment Management
+
+- **`make dev-up`** / **`make dev-start`** - Start the Podman Compose stack
+  - Starts PostgreSQL and Mattermost containers
+  - Waits for Mattermost to be ready
+  - Data persists between restarts
+
+- **`make dev-down`** / **`make dev-stop`** - Stop the stack
+  - Stops containers but preserves data
+  - Use this for daily development (faster than clean)
+
+- **`make dev-restart`** - Restart the stack
+  - Equivalent to `dev-down` followed by `dev-up`
+
+- **`make dev-clean`** - Clean everything
+  - Stops containers
+  - Removes volumes and all data
+  - Use this when you want a completely fresh start
+  - **Warning:** This deletes all Mattermost data, users, and settings
+
+### Plugin Management
+
+- **`make dev-deploy`** - Build and deploy plugin
+  - Builds the plugin bundle
+  - Uploads to the running Mattermost instance
+  - Requires `MM_ADMIN_TOKEN` or `MM_ADMIN_USERNAME`/`MM_ADMIN_PASSWORD` to be set
+
+- **`make dev-enable`** - Enable the plugin
+  - Enables the plugin in the development environment
+  - Verifies Mattermost container is running
+  - Loads credentials from `podman/.env` if present
+
+- **`make dev-disable`** - Disable the plugin
+  - Disables the plugin in the development environment
+  - Verifies Mattermost container is running
+
+- **`make dev-reset`** - Reset the plugin
+  - Disables and re-enables the plugin (useful for testing)
+  - Verifies Mattermost container is running
+
+### Debugging and Monitoring
+
+- **`make dev-logs`** - View Mattermost server logs
+  - Shows recent logs from the Mattermost container
+
+- **`make dev-logs-watch`** - Tail logs in real-time
+  - Follows Mattermost logs as they are generated
+  - Useful for debugging plugin issues
+  - Press Ctrl+C to stop
+
+- **`make dev-plugin-logs`** - View plugin logs
+  - Shows plugin-specific logs from the development environment
+  - Useful for debugging plugin behavior
+
+- **`make dev-plugin-logs-watch`** - Tail plugin logs in real-time
+  - Follows plugin logs as they are generated
+  - Useful for real-time plugin debugging
+  - Press Ctrl+C to stop
+
+- **`make dev-shell`** - Open shell in Mattermost container
+  - Provides interactive shell access for debugging
+  - Useful for inspecting files, checking processes, etc.
+
+- **`make dev-status`** - Show container status
+  - Lists running containers and their status
+  - Quick way to verify the stack is running
+
+## Configuration
+
+### Environment Variables
+
+The Podman Compose setup uses environment variables from:
+
+1. `podman/.env` file (if it exists)
+2. Shell environment variables
+3. Default values in `podman-compose.yml`
+
+To customize the environment:
+
+1. Copy the example file:
+
+   ```bash
+   cp podman/env.example podman/.env
+   ```
+
+2. Edit `podman/.env` with your preferences:
+   - Database credentials
+   - Admin user credentials
+   - Site URL (default: http://localhost:8065)
+
+3. The `.env` file is gitignored, so your local settings won't be committed.
+
+### Default Configuration
+
+- **Site URL:** http://localhost:8065
+- **Database:** PostgreSQL 14
+- **Mattermost Version:** 9.3 (minimum required for plugin)
+- **Plugin Uploads:** Enabled
+- **Developer Mode:** Enabled (for debugging)
+
+## Common Workflows
+
+### Daily Development Workflow
+
+```bash
+# Start environment (if not already running)
+make dev-up
+
+# Make code changes...
+
+# Rebuild and redeploy plugin
+make dev-deploy
+
+# Enable plugin if needed
+make dev-enable
+
+# View logs to check for issues
+make dev-logs-watch
+
+# Test in browser at http://localhost:8065
+```
+
+### Clean Start Workflow
+
+```bash
+# Stop and clean everything
+make dev-clean
+
+# Start fresh
+make dev-up
+
+# Set up Mattermost (first-time setup)
+# Open http://localhost:8065 in browser
+
+# Configure deployment credentials
+export MM_ADMIN_TOKEN="your-token"
+
+# Deploy and enable plugin
+make dev-deploy
+make dev-enable
+```
+
+### Troubleshooting Permission Issues
+
+The setup process automatically creates the required directories with proper permissions via the `dev-setup` target. However, if you encounter permission issues with the config or data directories, you can manually fix them:
+
+```bash
+chmod -R 777 podman/config podman/data/mattermost
+```
+
+### Debugging Workflow
+
+```bash
+# View logs
+make dev-logs-watch
+
+# Check container status
+make dev-status
+
+# Access container shell
+make dev-shell
+
+# Inside the shell, you can:
+# - Check plugin files: ls -la /mattermost/plugins/
+# - View Mattermost config: cat /mattermost/config/config.json
+# - Check logs: tail -f /mattermost/logs/mattermost.log
+```
+
+## Troubleshooting
+
+### Mattermost Won't Start
+
+**Symptoms:** `make dev-up` completes but Mattermost isn't accessible
+
+**Solutions:**
+
+1. Check container status: `make dev-status`
+2. View logs: `make dev-logs`
+3. Check if port 8065 is already in use:
+
+   ```bash
+   lsof -i :8065
+   ```
+
+4. Restart the stack: `make dev-restart`
+
+### Plugin Deployment Fails
+
+**Symptoms:** `make dev-deploy` fails with authentication error
+
+**Solutions:**
+
+1. Verify credentials are set:
+
+   ```bash
+   echo $MM_ADMIN_TOKEN
+   # or
+   echo $MM_ADMIN_USERNAME
+   ```
+
+2. Check if Mattermost is ready:
+
+   ```bash
+   curl http://localhost:8065/api/v4/system/ping
+   ```
+
+3. Verify admin user exists and credentials are correct
+4. Generate a new token from System Console if needed
+
+### Database Connection Issues
+
+**Symptoms:** Mattermost logs show database connection errors
+
+**Solutions:**
+
+1. Check PostgreSQL container is running: `make dev-status`
+2. Restart the stack: `make dev-restart`
+3. If issues persist, try a clean start: `make dev-clean` then `make dev-start`
+
+### Port Already in Use
+
+**Symptoms:** Podman Compose fails with "port already allocated"
+
+**Solutions:**
+
+1. Find what's using the port:
+
+   ```bash
+   lsof -i :8065
+   ```
+
+2. Stop the conflicting service, or
+3. Modify `podman-compose.yml` to use a different port:
+
+   ```yaml
+   ports:
+     - "8066:8065" # Use 8066 instead of 8065
+   ```
+
+   Then update `MM_SERVICESETTINGS_SITEURL` accordingly
+
+### Plugin Not Loading
+
+**Symptoms:** Plugin appears uploaded but doesn't activate
+
+**Solutions:**
+
+1. Check plugin compatibility with Mattermost version
+2. View logs for errors: `make dev-logs`
+3. Verify plugin was built correctly: `make dist`
+4. Check plugin permissions in container:
+
+   ```bash
+   make dev-shell
+   ls -la /mattermost/plugins/
+   ```
+
+### Data Persistence Issues
+
+**Symptoms:** Changes disappear after restart
+
+**Solutions:**
+
+1. Verify volumes are mounted: `podman volume ls`
+2. Check data directories exist: `ls -la podman/data/`
+3. Ensure you're using `dev-down` (not `dev-clean`) for normal stops
+
+## File Structure
+
+```txt
+.
+├── podman-compose.yml          # Podman Compose configuration
+├── podman/
+│   ├── env.example             # Example environment variables
+│   ├── .env                    # Local environment overrides (gitignored)
+│   ├── config/                 # Mattermost config files (gitignored)
+│   └── data/                   # Persistent data (gitignored)
+│       ├── mattermost/         # Mattermost data and plugins
+│       └── postgres/           # PostgreSQL data
+```
+
+## Accessing Mattermost
+
+- **Web UI:** http://localhost:8065
+- **API:** http://localhost:8065/api/v4
+- **Admin Console:** System Console (access via hamburger menu when logged in as admin)
+
+## Integration with Existing Workflow
+
+The Podman development environment works alongside existing deployment methods:
+
+- **`make deploy`** - Deploys to server configured via environment variables (works with any Mattermost instance)
+- **`make dev-deploy`** - Specifically deploys to the local Podman stack
+
+You can use either method depending on your needs. The Podman stack is ideal for:
+
+- Isolated testing
+- CI/CD pipelines
+- Reproducible test environments
+- Development without affecting production
+
+## Best Practices
+
+1. **Use `dev-down` for daily stops** - Preserves your test data and configuration
+2. **Use `dev-clean` sparingly** - Only when you need a completely fresh environment
+3. **Set up environment variables** - Create `podman/.env` for consistent configuration
+4. **Monitor logs during development** - Keep `make dev-logs-watch` running in a separate terminal
+5. **Version control** - Don't commit `podman/.env` or `podman/data/` (already in `.gitignore`)
+
+## Additional Resources
+
+- [Mattermost Plugin Development Documentation](https://developers.mattermost.com/integrate/plugins/)
+- [Podman Compose Documentation](https://github.com/containers/podman-compose)
+- [Mattermost Docker Hub](https://hub.docker.com/r/mattermost/mattermost-team-edition)

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,0 +1,68 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: docker.io/library/postgres:14
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-mmuser}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mmuser_password}
+      POSTGRES_DB: ${POSTGRES_DB:-mattermost}
+    volumes:
+      - ./podman/data/postgres:/var/lib/postgresql/data:z
+    networks:
+      - mattermost-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-mmuser}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mattermost:
+    image: docker.io/mattermost/mattermost-team-edition:9.3
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      # Database
+      MM_SQLSETTINGS_DRIVERNAME: postgres
+      MM_SQLSETTINGS_DATASOURCE: postgres://${POSTGRES_USER:-mmuser}:${POSTGRES_PASSWORD:-mmuser_password}@postgres:5432/${POSTGRES_DB:-mattermost}?sslmode=disable&connect_timeout=10
+
+      # Site URL
+      MM_SERVICESETTINGS_SITEURL: ${MM_SERVICESETTINGS_SITEURL:-http://localhost:8065}
+
+      # Admin credentials (for first-time setup)
+      MM_ADMIN_USERNAME: ${MM_ADMIN_USERNAME:-admin}
+      MM_ADMIN_PASSWORD: ${MM_ADMIN_PASSWORD:-admin123}
+      MM_ADMIN_EMAIL: ${MM_ADMIN_EMAIL:-admin@example.com}
+
+      # Enable plugin uploads
+      MM_PLUGINSETTINGS_ENABLEUPLOADS: "true"
+
+      # Local mode (if needed for pluginctl socket access)
+      MM_LOCALSOCKETPATH: /tmp/mattermost_local.socket
+      MM_LOCALSOCKETENABLE: "false"
+
+      # Additional settings
+      MM_LOGSETTINGS_ENABLECONSOLE: "true"
+      MM_LOGSETTINGS_CONSOLELEVEL: "DEBUG"
+      MM_SERVICESETTINGS_ENABLEDEVELOPER: "true"
+    volumes:
+      - ./podman/data/mattermost:/mattermost/data:z
+      - ./podman/data/mattermost/plugins:/mattermost/plugins:z
+      - ./podman/data/mattermost/client/plugins:/mattermost/client/plugins:z
+      - ./podman/config:/mattermost/config:z
+    ports:
+      - "8065:8065"
+    networks:
+      - mattermost-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8065/api/v4/system/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+networks:
+  mattermost-network:
+    driver: bridge

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,7 +1,16 @@
 version: '3.8'
 
+x-security: &security-defaults
+  security_opt:
+    - label=disable
+  userns_mode: keep-id
+
+x-podman:
+  in_pod: false
+
 services:
   postgres:
+    <<: *security-defaults
     image: docker.io/library/postgres:14
     restart: unless-stopped
     environment:
@@ -9,7 +18,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mmuser_password}
       POSTGRES_DB: ${POSTGRES_DB:-mattermost}
     volumes:
-      - ./podman/data/postgres:/var/lib/postgresql/data:z
+      - ./podman/data/postgres:/var/lib/postgresql/data
     networks:
       - mattermost-network
     healthcheck:
@@ -19,6 +28,7 @@ services:
       retries: 5
 
   mattermost:
+    <<: *security-defaults
     image: docker.io/mattermost/mattermost-team-edition:9.3
     restart: unless-stopped
     depends_on:
@@ -49,10 +59,10 @@ services:
       MM_LOGSETTINGS_CONSOLELEVEL: "DEBUG"
       MM_SERVICESETTINGS_ENABLEDEVELOPER: "true"
     volumes:
-      - ./podman/data/mattermost:/mattermost/data:z
-      - ./podman/data/mattermost/plugins:/mattermost/plugins:z
-      - ./podman/data/mattermost/client/plugins:/mattermost/client/plugins:z
-      - ./podman/config:/mattermost/config:z
+      - ./podman/data/mattermost:/mattermost/data
+      - ./podman/data/mattermost/plugins:/mattermost/plugins
+      - ./podman/data/mattermost/client/plugins:/mattermost/client/plugins
+      - ./podman/config:/mattermost/config
     ports:
       - "8065:8065"
     networks:

--- a/podman/env.example
+++ b/podman/env.example
@@ -1,0 +1,24 @@
+# PostgreSQL Configuration
+POSTGRES_USER=mmuser
+POSTGRES_PASSWORD=mmuser_password
+POSTGRES_DB=mattermost
+
+# Mattermost Configuration
+MM_SERVICESETTINGS_SITEURL=http://localhost:8065
+
+# Admin User (for Mattermost first-time setup)
+# These are used by Mattermost during initial configuration
+MM_ADMIN_USERNAME=admin
+MM_ADMIN_PASSWORD=admin123
+MM_ADMIN_EMAIL=admin@example.com
+
+# Plugin Deployment Credentials (for pluginctl)
+# Set these AFTER creating your admin user to enable API-based plugin deployment
+# Option 1: Use an admin token (recommended)
+# Generate from: System Console > Integrations > Bot Accounts > Personal Access Tokens
+MM_ADMIN_TOKEN=
+
+# Option 2: Use username/password (alternative to token)
+# If using token above, these can be left empty
+# MM_ADMIN_USERNAME=admin
+# MM_ADMIN_PASSWORD=admin123


### PR DESCRIPTION
This change adds a local mattermost development environment which runs in podman. The change includes a set of `make dev-*` make targets which are used to manage the local development environment. In the newly created `/docs` directory there is a document which explains how to make use of the local development environment. 